### PR TITLE
Added option to change the delimiter #8

### DIFF
--- a/ParametersXmlAddin/ParametersXmlAddin/OptionPageGrid.cs
+++ b/ParametersXmlAddin/ParametersXmlAddin/OptionPageGrid.cs
@@ -10,8 +10,10 @@ namespace BlackMarble.ParametersXmlAddin
 {
      public class OptionPageGrid : DialogPage
     {
+        public const string DEFAULTDELIMITER = "__";
         private bool makeTokenUpperCase = true;
         private bool addDefaultDescription = true;
+        private string delimiter = DEFAULTDELIMITER;
 
         [Category("Options")]
         [DisplayName("Make Tokens Uppercase")]
@@ -30,5 +32,15 @@ namespace BlackMarble.ParametersXmlAddin
             get { return addDefaultDescription; }
             set { addDefaultDescription = value; }
         }
+
+        [Category("Options")]
+        [DisplayName("Replacement Delimiter")]
+        [Description("The delimiter to be used to find items to be replaced in later processing")]
+        public string Delimiter
+        {
+            get { return delimiter; }
+            set { delimiter = value; }
+        }
+
     }
 }

--- a/ParametersXmlAddin/ParametersXmlAddin/ParametersXmlAddinPackage.cs
+++ b/ParametersXmlAddin/ParametersXmlAddin/ParametersXmlAddinPackage.cs
@@ -137,8 +137,9 @@ namespace BlackMarble.ParametersXmlAddin
                     webConfigPath,
                     parametersXmlPath,
                     this.MakeTokenUpperCase, 
-                    this.AddDefaultDescription);
-
+                    this.AddDefaultDescription,
+                    this.Delimiter);
+                
                 // add it to the project, this can be run multiple times
                 VSHelper.AddFileToProject(vsProject, parametersXmlPath);
 
@@ -155,7 +156,8 @@ namespace BlackMarble.ParametersXmlAddin
                     webConfigPath,
                     parametersXmlPath,
                     this.MakeTokenUpperCase, 
-                    this.AddDefaultDescription);
+                    this.AddDefaultDescription,
+                    this.Delimiter);
 
                 // add it to the project, this can be run multiple times
                 VSHelper.AddFileToProject(vsProject, parametersXmlPath);
@@ -249,6 +251,18 @@ namespace BlackMarble.ParametersXmlAddin
             {
                 OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
                 return page.MakeTokenUpperCase;
+            }
+        }
+
+        /// <summary>
+        /// Get option settings for delimiter
+        /// </summary>
+        public string Delimiter
+        {
+            get
+            {
+                OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
+                return page.Delimiter;
             }
         }
 

--- a/ParametersXmlAddin/ParametersXmlAddin/XmlGenerator.cs
+++ b/ParametersXmlAddin/ParametersXmlAddin/XmlGenerator.cs
@@ -17,6 +17,25 @@ namespace BlackMarble.ParametersXmlAddin
     internal static class XmlGenerator
     {
         /// <summary>
+        /// Replaces the delimiter in use in the template
+        /// </summary>
+        /// <param name="fileName">The file to update</param>
+        /// <param name="oldDelimiter">Old delimiter - usually __</param>
+        /// <param name="newDelimiter">What ever you need</param>
+        /// <returns></returns>
+        internal static void SwapDelimiter(string fileName, string oldDelimiter, string newDelimiter)
+        {
+            if (!oldDelimiter.Equals(newDelimiter))
+            {
+                var fileContent = File.ReadAllText(fileName, System.Text.Encoding.UTF8);
+                File.WriteAllText(
+                    fileName,
+                    fileContent.Replace(oldDelimiter, newDelimiter),
+                    System.Text.Encoding.UTF8);
+            }
+        }
+
+        /// <summary>
         /// Gets the name of the XSLT transform resource
         /// </summary>
         /// <param name="forceUppercase">Set the token as upper case</param>
@@ -56,15 +75,16 @@ namespace BlackMarble.ParametersXmlAddin
         /// <param name="outFile">The target parameters.xml</param>
         /// <param name="forceUppercase">Set the token as upper case</param>
         /// <param name="addDescription">Add a description</param>
+        /// <param name="delimiter">Demlimter override</param>
 
         internal static void GenerateParametersXmlFile(
             string inFile,
             string outFile,
             bool forceUppercase,
-            bool addDescription)
+            bool addDescription,
+            string delimiter)
         {
             var transformFile = XmlGenerator.GetTransformresourceName(forceUppercase, addDescription);
-
             using (var strm = Assembly.GetExecutingAssembly().GetManifestResourceStream(transformFile))
             {
                 using (XmlReader reader = XmlReader.Create(strm))
@@ -75,6 +95,7 @@ namespace BlackMarble.ParametersXmlAddin
                     GenerateParametersXmlFile(inFile, outFile, transform);
                 }
             }
+            XmlGenerator.SwapDelimiter(outFile, OptionPageGrid.DEFAULTDELIMITER, delimiter);
         }
 
         /// <summary>
@@ -101,14 +122,22 @@ namespace BlackMarble.ParametersXmlAddin
         /// <param name="parametersXmlPath">The target parameters.xml</param>
         /// <param name="forceUppercase">Set the token as upper case</param>
         /// <param name="addDescription">Add a description</param>
+        /// <param name="delimiter">Delimiter to be used for replacement</param>
 
         internal static void UpdateParametersXmlFile(
             string webConfigPath,
             string parametersXmlPath,
-             bool forceUppercase,
-            bool addDescription)
+            bool forceUppercase,
+            bool addDescription,
+            string delimiter)
         {
-            UpdateParametersXmlFile(webConfigPath, parametersXmlPath, System.IO.Path.GetTempFileName(), forceUppercase, addDescription);
+            UpdateParametersXmlFile(
+                webConfigPath, 
+                parametersXmlPath, 
+                System.IO.Path.GetTempFileName(), 
+                forceUppercase, 
+                addDescription,
+                delimiter);
         }
 
         /// <summary>
@@ -120,13 +149,16 @@ namespace BlackMarble.ParametersXmlAddin
         /// <param name="newParametersXmlPath">The temporary location to generate the file into</param>
         /// <param name="forceUppercase">Set the token as upper case</param>
         /// <param name="addDescription">Add a description</param>
+        /// <param name="delimiter">Delimiter to be used for replacement</param>
 
         internal static void UpdateParametersXmlFile(
             string webConfigPath,
             string existingParametersXmlPath,
             string newParametersXmlPath,
             bool forceUppercase,
-            bool addDescription)
+            bool addDescription,
+            string delimiter)
+
         {
             var transformFile = XmlGenerator.GetTransformresourceName(forceUppercase, addDescription);
 
@@ -140,6 +172,7 @@ namespace BlackMarble.ParametersXmlAddin
                     UpdateParametersXmlFile(webConfigPath, existingParametersXmlPath, newParametersXmlPath, transform);
                 }
             }
+            XmlGenerator.SwapDelimiter(existingParametersXmlPath, OptionPageGrid.DEFAULTDELIMITER, delimiter);
         }
 
         /// <summary>

--- a/ParametersXmlAddin/ParametersXmlAddin/source.extension.vsixmanifest
+++ b/ParametersXmlAddin/ParametersXmlAddin/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="633e9230-4287-47ed-8a7a-bbbdc80569f4" Version="1.5" Language="en-US" Publisher="Richard Fennell" />
+    <Identity Id="633e9230-4287-47ed-8a7a-bbbdc80569f4" Version="1.6" Language="en-US" Publisher="Richard Fennell" />
     <DisplayName>Parameters.Xml Generator</DisplayName>
     <Description xml:space="preserve">A tool to generate parameters.xml files for MSdeploy from existing web.config files.
 

--- a/ParametersXmlAddin/ParametersXmlAddin_UnitTests/ParametersXmlAddin_UnitTests.csproj
+++ b/ParametersXmlAddin/ParametersXmlAddin_UnitTests/ParametersXmlAddin_UnitTests.csproj
@@ -120,6 +120,16 @@
       <Name>ParametersXmlAddin</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Testdata\ParametersMixedcaseWithDescriptionDelimiterSwapped.XML">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Testdata\ParametersUppercaseWithDescriptionDelimiterSwapper - Update.XML">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/ParametersXmlAddin/ParametersXmlAddin_UnitTests/Testdata/ParametersMixedcaseWithDescriptionDelimiterSwapped.XML
+++ b/ParametersXmlAddin/ParametersXmlAddin_UnitTests/Testdata/ParametersMixedcaseWithDescriptionDelimiterSwapped.XML
@@ -1,0 +1,28 @@
+﻿<parameters>
+  
+  <parameter name="APPSETTING1" description="Description for APPSETTING1" defaultvalue="##APPSETTING1##" tags="">
+    <parameterentry kind="XmlFile" scope="\\web.config$" match="/configuration/appSettings/add[@key='APPSETTING1']/@value" />
+  </parameter>
+
+  <parameter name="AppSetting2" description="Description for AppSetting2" defaultvalue="##AppSetting2##" tags="">
+    <parameterentry kind="XmlFile" scope="\\web.config$" match="/configuration/appSettings/add[@key='AppSetting2']/@value" />
+   </parameter>
+
+  <parameter name="Directory1"
+            description="Description for Directory1"
+            defaultvalue="##Directory1##" tags="">
+    <parameterentry kind="XmlFile"
+                    scope="\\web.config$"
+                    match="/configuration/applicationSettings/Service.Properties.Settings/setting[@name='Directory1']/value/text()" />
+  </parameter>
+
+  <parameter name="Directory2"
+          description="Description for Directory2"
+          defaultvalue="##Directory2##" tags="">
+    <parameterentry kind="XmlFile"
+                    scope="\\web.config$"
+                    match="/configuration/applicationSettings/Service.Properties.Settings/setting[@name='Directory2']/value/text()" />
+  </parameter>
+
+
+</parameters>

--- a/ParametersXmlAddin/ParametersXmlAddin_UnitTests/Testdata/ParametersUppercaseWithDescriptionDelimiterSwapper - Update.XML
+++ b/ParametersXmlAddin/ParametersXmlAddin_UnitTests/Testdata/ParametersUppercaseWithDescriptionDelimiterSwapper - Update.XML
@@ -1,0 +1,28 @@
+﻿<parameters>
+  
+  <parameter name="APPSETTING1" description="Description for APPSETTING1" defaultvalue="##APPSETTING1##" tags="">
+    <parameterentry kind="XmlFile" scope="\\web.config$" match="/configuration/appSettings/add[@key='APPSETTING1']/@value" />
+  </parameter>
+
+  <parameter name="AppSetting2" description="Description for AppSetting2" defaultvalue="##APPSETTING2##" tags="">
+    <parameterentry kind="XmlFile" scope="\\web.config$" match="/configuration/appSettings/add[@key='AppSetting2']/@value" />
+   </parameter>
+
+  <parameter name="Directory1"
+            description="Description for Directory1"
+            defaultvalue="##DIRECTORY1##" tags="">
+    <parameterentry kind="XmlFile"
+                    scope="\\web.config$"
+                    match="/configuration/applicationSettings/Service.Properties.Settings/setting[@name='Directory1']/value/text()" />
+  </parameter>
+
+  <parameter name="Directory2"
+          description="Description for Directory2"
+          defaultvalue="##DIRECTORY2##" tags="">
+    <parameterentry kind="XmlFile"
+                    scope="\\web.config$"
+                    match="/configuration/applicationSettings/Service.Properties.Settings/setting[@name='Directory2']/value/text()" />
+  </parameter>
+
+
+</parameters>

--- a/ParametersXmlAddin/ParametersXmlAddin_UnitTests/XmlTest.cs
+++ b/ParametersXmlAddin/ParametersXmlAddin_UnitTests/XmlTest.cs
@@ -79,7 +79,12 @@ namespace ParametersXmlAddin_UnitTests
             var actualFile = "results.xml";
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(sourceFile, actualFile, true, true);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(
+                sourceFile, 
+                actualFile, 
+                true, 
+                true,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
             // Assert
             XmlAssert.AreEqual(
@@ -96,7 +101,12 @@ namespace ParametersXmlAddin_UnitTests
             var actualFile = "results.xml";
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(sourceFile, actualFile, false, true);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(
+                sourceFile, 
+                actualFile, 
+                false, 
+                true,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
             // Assert
             XmlAssert.AreEqual(
@@ -113,7 +123,12 @@ namespace ParametersXmlAddin_UnitTests
             var actualFile = "results.xml";
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(sourceFile, actualFile, true, false);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(
+                sourceFile, 
+                actualFile, 
+                true, 
+                false,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
             // Assert
             XmlAssert.AreEqual(
@@ -130,8 +145,36 @@ namespace ParametersXmlAddin_UnitTests
             var actualFile = "results.xml";
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(sourceFile, actualFile, false, false);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(
+                sourceFile, 
+                actualFile, 
+                false,
+                false,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
+            // Assert
+            XmlAssert.AreEqual(
+                File.ReadAllText(requiredFile, System.Text.Encoding.UTF8),
+                File.ReadAllText(actualFile, System.Text.Encoding.UTF8));
+        }
+
+        [TestMethod]
+        public void Can_generate_a_new_parameters_file_in_mixedcase_with_description_swap_delimiter()
+        {
+            // Arrange 
+            var sourceFile = Path.Combine(GetWorkingFolder(), @"testdata\web.config");
+            var requiredFile = Path.Combine(GetWorkingFolder(), @"testdata\ParametersMixedcaseWithDescriptionDelimiterSwapped.xml");
+            var actualFile = "results.xml";
+
+            // act
+            BlackMarble.ParametersXmlAddin.XmlGenerator.GenerateParametersXmlFile(
+                sourceFile,
+                actualFile,
+                false,
+                true,
+                "##");
+
+            Console.WriteLine(File.ReadAllText(actualFile, System.Text.Encoding.UTF8));
             // Assert
             XmlAssert.AreEqual(
                 File.ReadAllText(requiredFile, System.Text.Encoding.UTF8),
@@ -148,7 +191,35 @@ namespace ParametersXmlAddin_UnitTests
             File.Copy(Path.Combine(GetWorkingFolder(), @"testdata\ParametersMissingEntries.XML"), existingFile,true);
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(sourceFile, existingFile, true, true);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(
+                sourceFile, 
+                existingFile, 
+                true, 
+                true,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
+
+            // assert
+            XmlAssert.AreEqual(
+                File.ReadAllText(requiredFile, System.Text.Encoding.UTF8),
+                File.ReadAllText(existingFile, System.Text.Encoding.UTF8));
+        }
+
+        [TestMethod]
+        public void Can_update_and_existing_parameters_file_with_uppercase_and_description_swap_delimiter()
+        {
+            // Arrange 
+            var sourceFile = Path.Combine(GetWorkingFolder(), @"testdata\web.config");
+            var requiredFile = Path.Combine(GetWorkingFolder(), @"testdata\ParametersUppercaseWithDescriptionDelimiterSwapper - Update.xml");
+            var existingFile = Path.Combine(GetWorkingFolder(), @"testdata\TestFile.XML");
+            File.Copy(Path.Combine(GetWorkingFolder(), @"testdata\ParametersMissingEntries.XML"), existingFile, true);
+
+            // act
+            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(
+                sourceFile,
+                existingFile,
+                true,
+                true,
+                "##");
 
             // assert
             XmlAssert.AreEqual(
@@ -166,7 +237,12 @@ namespace ParametersXmlAddin_UnitTests
             File.Copy(Path.Combine(GetWorkingFolder(), @"testdata\ParametersMissingEntries.XML"), existingFile, true);
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(sourceFile, existingFile, false, true);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(
+                sourceFile, 
+                existingFile, 
+                false, 
+                true,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
             // assert
             XmlAssert.AreEqual(
@@ -185,7 +261,12 @@ namespace ParametersXmlAddin_UnitTests
             File.Copy(Path.Combine(GetWorkingFolder(), @"testdata\ParametersMissingEntries.XML"), existingFile, true);
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(sourceFile, existingFile, true, false);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(
+                sourceFile, 
+                existingFile, 
+                true, 
+                false,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
             // assert
             XmlAssert.AreEqual(
@@ -203,7 +284,12 @@ namespace ParametersXmlAddin_UnitTests
             File.Copy(Path.Combine(GetWorkingFolder(), @"testdata\ParametersMissingEntries.XML"), existingFile, true);
 
             // act
-            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(sourceFile, existingFile, false, false);
+            BlackMarble.ParametersXmlAddin.XmlGenerator.UpdateParametersXmlFile(
+                sourceFile, 
+                existingFile, 
+                false, 
+                false,
+                BlackMarble.ParametersXmlAddin.OptionPageGrid.DEFAULTDELIMITER);
 
             // assert
             XmlAssert.AreEqual(


### PR DESCRIPTION
In previous versions the delimiter around the values to replace was __, by allowing a user to change the demiter they can remove any potential clashes with other delimiters